### PR TITLE
feedコマンドの出力にある"message"を削除する

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -87,8 +87,7 @@ async function handleFeedCommand(args: string[]) {
   
   // 記事一覧のみを表示
   const output = {
-    articles: result.value,
-    message: "記事の詳細を取得するには: zennfeed article --url <記事のURL>"
+    articles: result.value
   };
   console.log(JSON.stringify(output, null, 2));
 }


### PR DESCRIPTION
## Summary
- feedコマンドの出力からmessageフィールドを削除しました
- JSON出力をよりシンプルにし、articlesフィールドのみを返すようにしました

## Test plan
- feedコマンドを実行し、出力からmessageフィールドが削除されていることを確認
- JSONの構造がarticlesフィールドのみになっていることを確認

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)