### PR TITLE
README.mdの「開発」と「今後の改善予定」セクションを別ファイルに移動

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## GitHub操作
 
 - プッシュ: `gh repo push` または `git push origin main`
-- PR作成: `gh pr create --title "PRタイトル" --body "PR詳細"`
+- PR作成: `gh pr create --title "PRタイトル" --body "PR詳細"` (テスト項目は不要)
 - PR確認: `gh pr view`
 - コミット履歴: `gh repo view --commits`
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,36 @@
+# 開発ガイド
+
+## 開発コマンド
+
+```bash
+# 開発モード（ファイル変更を監視）
+deno run --watch --allow-net mod.ts
+
+# リント
+deno lint
+
+# フォーマット
+deno fmt
+
+# 型チェック
+deno check mod.ts
+
+# テスト
+deno test
+
+# バンドル
+deno bundle mod.ts dist.js
+
+# 実行ファイルにコンパイル
+deno compile --allow-net mod.ts
+```
+
+## 今後の改善予定
+
+- 公開日の抽出方法を改善
+  - メタタグからの抽出を試す (og:published_time など)
+  - 日付のフォーマットを標準化 (ISO 8601 形式など)
+  - タイムゾーン処理の追加
+- HTML スクレイピング処理の堅牢性向上
+- 記事タグの抽出精度の向上
+- 出力形式の選択肢追加（JSON 以外）

--- a/README.md
+++ b/README.md
@@ -109,28 +109,7 @@ zennfeed article --help
 
 ## 開発
 
-```bash
-# 開発モード（ファイル変更を監視）
-deno run --watch --allow-net mod.ts
-
-# リント
-deno lint
-
-# フォーマット
-deno fmt
-
-# 型チェック
-deno check mod.ts
-
-# テスト
-deno test
-
-# バンドル
-deno bundle mod.ts dist.js
-
-# 実行ファイルにコンパイル
-deno compile --allow-net mod.ts
-```
+詳細な開発方法については [DEVELOPMENT.md](./DEVELOPMENT.md) を参照してください。
 
 ## 出力例
 
@@ -194,13 +173,3 @@ deno compile --allow-net mod.ts
 ## ライセンス
 
 MIT
-
-## 今後の改善予定
-
-- 公開日の抽出方法を改善
-  - メタタグからの抽出を試す (og:published_time など)
-  - 日付のフォーマットを標準化 (ISO 8601 形式など)
-  - タイムゾーン処理の追加
-- HTML スクレイピング処理の堅牢性向上
-- 記事タグの抽出精度の向上
-- 出力形式の選択肢追加（JSON 以外）


### PR DESCRIPTION
## 概要
- README.mdから「開発」と「今後の改善予定」セクションを削除し、DEVELOPMENT.mdに移動
- READMEにDEVELOPMENT.mdへのリンクを追加

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)