### PR TITLE
GitHub Actionsのdeno fmt --checkコマンドでチェック対象を*.tsのみに限定

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           deno-version: v1.x
 
       - name: Verify formatting
-        run: deno fmt --check
+        run: deno fmt --check "**/*.ts"
 
       - name: Run linter
         run: deno lint


### PR DESCRIPTION
## Summary
- GitHub Actionsの実行時に`deno fmt --check`コマンドでチェックする対象を`**/*.ts`のみに限定
- issue #11の対応

🤖 Generated with [Claude Code](https://claude.ai/code)