### PR TITLE
feedコマンドでフィードURLを表示する機能を追加 (issue #22)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -61,3 +61,4 @@ deno compile --allow-net mod.ts
 - HTML スクレイピング処理の堅牢性向上
 - 記事タグの抽出精度の向上
 - ~~出力形式の選択肢追加（JSON 以外）~~ ✅ issue #14 で実装完了
+- ~~feedコマンドでフィードURLを表示~~ ✅ issue #22 で実装完了

--- a/mod.ts
+++ b/mod.ts
@@ -97,7 +97,9 @@ async function handleFeedCommand(args: string[]) {
   }
 
   // 指定されたフォーマットで出力
-  console.log(formatFeedOutput(result.value, format));
+  console.log(
+    formatFeedOutput(result.value.articles, format, result.value.feedUrl),
+  );
 }
 
 /**

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,11 @@
 import { parseFeed } from "https://deno.land/x/rss@1.0.0/mod.ts";
-import { Article, ExtendedFeedEntry, FeedFilter, Result } from "./types.ts";
+import {
+  Article,
+  ExtendedFeedEntry,
+  Feed,
+  FeedFilter,
+  Result,
+} from "./types.ts";
 import { formatDate } from "./utils.ts";
 
 /**
@@ -20,7 +26,7 @@ export function buildFeedUrl(filter: FeedFilter): string {
  */
 export async function fetchLatestArticles(
   options: { count?: number; filter?: FeedFilter } = {},
-): Promise<Result<{ articles: Article[]; feedUrl: string }, string>> {
+): Promise<Result<Feed, string>> {
   try {
     const { count = 20, filter = { type: "all" } } = options;
     const url = buildFeedUrl(filter);

--- a/src/api.ts
+++ b/src/api.ts
@@ -20,7 +20,7 @@ export function buildFeedUrl(filter: FeedFilter): string {
  */
 export async function fetchLatestArticles(
   options: { count?: number; filter?: FeedFilter } = {},
-): Promise<Result<Article[], string>> {
+): Promise<Result<{ articles: Article[]; feedUrl: string }, string>> {
   try {
     const { count = 20, filter = { type: "all" } } = options;
     const url = buildFeedUrl(filter);
@@ -76,7 +76,7 @@ export async function fetchLatestArticles(
       });
     }
 
-    return { ok: true, value: articles };
+    return { ok: true, value: { articles, feedUrl: url } };
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return { ok: false, error: `エラーが発生しました: ${errorMessage}` };

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -18,6 +18,13 @@ Deno.test("formatFeedOutput formats feed in text format", () => {
     "Test Article\n  https://zenn.dev/test/article\n  Test Author - 2023/07/09 19:30";
 
   assertEquals(formatted, expected);
+
+  // フィードURLがある場合
+  const feedUrl = "https://zenn.dev/feed";
+  const formattedWithUrl = formatFeedOutput(articles, "text", feedUrl);
+  const expectedWithUrl = `Feed URL: ${feedUrl}\n\n${expected}`;
+
+  assertEquals(formattedWithUrl, expectedWithUrl);
 });
 
 Deno.test("formatFeedOutput formats feed in json format", () => {
@@ -36,6 +43,14 @@ Deno.test("formatFeedOutput formats feed in json format", () => {
 
   assertEquals(parsed.articles.length, 1);
   assertEquals(parsed.articles[0].title, "Test Article");
+  assertEquals(parsed.feedUrl, undefined);
+
+  // フィードURLがある場合
+  const feedUrl = "https://zenn.dev/feed";
+  const formattedWithUrl = formatFeedOutput(articles, "json", feedUrl);
+  const parsedWithUrl = JSON.parse(formattedWithUrl);
+
+  assertEquals(parsedWithUrl.feedUrl, feedUrl);
 });
 
 Deno.test("formatFeedOutput formats feed in markdown format", () => {
@@ -54,6 +69,13 @@ Deno.test("formatFeedOutput formats feed in markdown format", () => {
     "- [Test Article](https://zenn.dev/test/article) by Test Author - 2023/07/09 19:30";
 
   assertEquals(formatted, expected);
+
+  // フィードURLがある場合
+  const feedUrl = "https://zenn.dev/feed";
+  const formattedWithUrl = formatFeedOutput(articles, "markdown", feedUrl);
+  const expectedWithUrl = `## Feed: [${feedUrl}](${feedUrl})\n\n${expected}`;
+
+  assertEquals(formattedWithUrl, expectedWithUrl);
 });
 
 Deno.test("formatArticleOutput formats article in text format", () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -9,19 +9,24 @@ import { Article, ArticleContent, OutputFormat } from "./types.ts";
 export function formatFeedOutput(
   articles: Article[],
   format: OutputFormat = "text",
+  feedUrl?: string,
 ): string {
+  const feedHeader = feedUrl ? `Feed URL: ${feedUrl}\n\n` : "";
+
   switch (format) {
     case "json":
-      return JSON.stringify({ articles }, null, 2);
-    case "markdown":
-      return articles
+      return JSON.stringify({ feedUrl, articles }, null, 2);
+    case "markdown": {
+      const mdHeader = feedUrl ? `## Feed: [${feedUrl}](${feedUrl})\n\n` : "";
+      return mdHeader + articles
         .map((article) =>
           `- [${article.title}](${article.link}) by ${article.author} - ${article.pubDateFormatted}`
         )
         .join("\n");
+    }
     case "text":
     default:
-      return articles
+      return feedHeader + articles
         .map((article) =>
           `${article.title}\n  ${article.link}\n  ${article.author} - ${article.pubDateFormatted}`
         )

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,14 @@ export type Article = {
 };
 
 /**
+ * フィードの記事一覧と取得元URL
+ */
+export type Feed = {
+  articles: Article[];
+  feedUrl: string;
+};
+
+/**
  * 記事の詳細コンテンツ
  */
 export type ArticleContent = {


### PR DESCRIPTION
## Summary
- feedコマンド実行時にフィードのURLを表示する機能を追加
- 各出力フォーマット（text, json, markdown）でのURL表示に対応
- 既存機能との互換性を維持

🤖 Generated with [Claude Code](https://claude.ai/code)