### PR TITLE
🤖 extractArticleContent()の中のバックアップタグ検出を削除

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -165,37 +165,7 @@ function extractArticleContent(html: string, url: string): ArticleContent {
     }
   }
 
-  // 3. コンテンツからの一般的なタグの検出（バックアップ）
-  if (result.tags.length === 0) {
-    const textContent = document.body ? document.body.textContent : "";
-    const potentialTags = [
-      "macOS",
-      "Docker",
-      "TypeScript",
-      "JavaScript",
-      "React",
-      "Vue",
-      "Node.js",
-      "Python",
-      "Go",
-      "Rust",
-      "AWS",
-      "Azure",
-      "GCP",
-      "Kubernetes",
-    ];
 
-    for (const tag of potentialTags) {
-      if (textContent.includes(tag) && !result.tags.includes(tag)) {
-        result.tags.push(tag);
-      }
-    }
-
-    // "tech" タグは頻出するので、コンテンツに含まれていない場合でもデフォルトで追加
-    if (!result.tags.includes("tech")) {
-      result.tags.push("tech");
-    }
-  }
 
   // 本文の抽出
   let mainElement = null;

--- a/src/content.ts
+++ b/src/content.ts
@@ -165,8 +165,6 @@ function extractArticleContent(html: string, url: string): ArticleContent {
     }
   }
 
-
-
   // 本文の抽出
   let mainElement = null;
 


### PR DESCRIPTION
🤖 extractArticleContent()関数内にあった「コンテンツからの一般的なタグの検出（バックアップ）」を削除しました。\n\nClose #20