### PR TITLE
🤖 キーワード検索機能を追加 (fixes #16)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,3 +51,17 @@ deno compile --allow-net mod.ts
 - 記事タグの抽出精度の向上
 - ~~出力形式の選択肢追加（JSON 以外）~~ ✅ issue #14 で実装完了
 - ~~feedコマンドでフィードURLを表示~~ ✅ issue #22 で実装完了
+- ~~キーワード検索機能の追加~~ ✅ issue #16 で実装完了
+
+## キーワード検索機能 (issue #16)
+
+`--search` または `-s` オプションを使用して、取得した記事の中からキーワードを含む記事をフィルタリングできます。
+現在の実装では、記事タイトルと著者名に対する検索をサポートしています。
+
+```bash
+# 例: 「Docker」を含む記事を検索
+zennfeed feed --search "Docker"
+
+# 例: typeと組み合わせて使用
+zennfeed feed typescript --search "API"
+```

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,22 @@
+import { Article } from "./types.ts";
+
+/**
+ * 記事一覧からキーワードにマッチする記事をフィルタリングする
+ * @param articles 記事一覧
+ * @param searchQuery 検索キーワード
+ * @returns 検索キーワードにマッチする記事一覧
+ */
+export function searchArticles(
+  articles: Article[],
+  searchQuery: string,
+): Article[] {
+  if (!searchQuery) {
+    return articles;
+  }
+
+  const query = searchQuery.toLowerCase();
+  return articles.filter((article) => {
+    return article.title.toLowerCase().includes(query) ||
+      article.author.toLowerCase().includes(query);
+  });
+}


### PR DESCRIPTION
## 概要
- issue #16 の対応として、キーワード検索機能を実装しました
- `--search` または `-s` オプションを使用して、取得した記事の中からキーワードを含む記事をフィルタリングできます

## 変更内容
- 新規ファイル `src/search.ts` を作成して検索機能を実装
- `mod.ts` に検索オプション `--search` または `-s` を追加
- ヘルプメッセージに検索オプションに関する説明と使用例を追加
- DEVELOPMENT.md に実装内容を記録

## 使用例
```bash
# 「Docker」を含む記事を検索
zennfeed feed --search "Docker"

# トピックと組み合わせて使用
zennfeed feed typescript --search "API"
```

## 今後の改善点
- 現在は記事タイトルと著者名だけを検索対象としていますが、将来的にはタグやコンテンツ本文なども検索対象に含めることが考えられます
